### PR TITLE
Uncaught exception in node-red

### DIFF
--- a/lib/connectionFSM.js
+++ b/lib/connectionFSM.js
@@ -90,7 +90,8 @@
               self.debug && console.log('Ping timeout');
               self.transition('connecting');
             }.bind(this), this.PING_TIMEOUT);
-
+            
+            this.connection = new MarantzHTTP(this.host, this.port);
             this.connection.getState().then(function(state) {
               self.debug && console.log('Ping success, pong_state[' + state + ']');
               self.transition('connected');


### PR DESCRIPTION
```` 
TypeError: Cannot read property 'getState' of null at machina.Fsm.states.pinging._onEnter (/home/pi/.node-red/node_modules/node-red-contrib-marantz-http/lib/connectionFSM.js: at 
_.extend.transition (/home/pi/.node-red/node_modules/node-red-contrib-marantz-http/node_modules/machina/lib/machina.js:4 at Fsm.(anonymous function) [as transition] (/home/pi/.node-red/node_modules/node-red-contrib-marantz-http/node_modules/mac at 
null.<anonymous> (/home/pi/.node-red/node_modules/node-red-contrib-marantz-http/lib/connectionFSM.js:79:20) at Timer.listOnTimeout (timers.js:92:15)
````

This error made node-red crash and restart continuously. The proposed line solves the error (not sure of it can be more efficient)